### PR TITLE
Update Jenkinsfile syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 #!/usr/bin/env groovy
 
 /* https://github.com/jenkins-infra/pipeline-library */
-buildPlugin()
+buildPluginWithGradle(useContainerAgent: true)


### PR DESCRIPTION
The buildPlugin syntax is reserved for plugins using maven, and deprecated for plugins using gradle to build.
The change proposed updates the syntax to use the proper buildPluginWithGradle build step.